### PR TITLE
Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OBJS=cbmbasic.o runtime.o plugin.o console.o
-CFLAGS+=-Wall -O3
+CFLAGS+=-Wall
 
 all: cbmbasic
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS+=-Wall -O3
 all: cbmbasic
 
 cbmbasic: $(OBJS)
-	$(CC) -o cbmbasic $(OBJS)
+	$(CC) $(LDFLAGS) -o cbmbasic $(OBJS)
 
 clean:
 	rm -f $(OBJS) cbmbasic

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 OBJS=cbmbasic.o runtime.o plugin.o console.o
-CFLAGS=-Wall -O3
+CFLAGS+=-Wall -O3
 
 all: cbmbasic
 


### PR DESCRIPTION
 - Respect existing CFLAGS by appending, rather than replacing
 - Respect LDFLAGS
 - Remove -O3 default. A matter of taste, but one could argue that this is something for the environment to set