### PR TITLE
Set RAM variable to extern to satisfy GCC 10 #8

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -44,7 +44,7 @@
 #include "glue.h"
 #include "console.h"
 
-unsigned char RAM[65536];
+extern unsigned char RAM[65536];
 
 int
 stack4(unsigned short a, unsigned short b, unsigned short c, unsigned short d) {


### PR DESCRIPTION
…ommon option rather than -fcommon in earlier versions of GCC.