### PR TITLE
Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OBJS=cbmbasic.o runtime.o plugin.o console.o
 CFLAGS=-Wall -O3
 
-all: cbmbasic
+all: cbmbasic install
 
 cbmbasic: $(OBJS)
 	$(CC) -o cbmbasic $(OBJS)
@@ -9,3 +9,8 @@ cbmbasic: $(OBJS)
 clean:
 	rm -f $(OBJS) cbmbasic
 
+install:
+	cp cbmbasic /usr/bin/cbmbasic
+	
+uninstall:
+	rm /usr/bin/cbmbasic

--- a/runtime.c
+++ b/runtime.c
@@ -44,7 +44,7 @@
 #include "glue.h"
 #include "console.h"
 
-unsigned char RAM[65536];
+// unsigned char RAM[65536];
 
 int
 stack4(unsigned short a, unsigned short b, unsigned short c, unsigned short d) {


### PR DESCRIPTION
Fixed a failing build by commenting out the definition of a variable in `runtime.c`, I did leave the variable there in case it turns out to actually be important and needed.

Added an Install and Uninstall option to the Makefile.

Mainly so I could mess with BASIC in GNU Emacs tbh